### PR TITLE
HDXDSYS-956 Update Dockerfile to use OCHA Python image not base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM public.ecr.aws/unocha/hdx-scraper-baseimage:stable
+FROM public.ecr.aws/unocha/python:3.12-stable
 
 WORKDIR /srv
 
 COPY . .
+
+RUN pip --no-cache-dir install --upgrade -r requirements.txt
 
 CMD ["python3", "run.py"]

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -1,1 +1,0 @@
-# FTS has no additional requirements to the base image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 python-slugify==8.0.4
 hdx-python-api==6.3.2
--r docker-requirements.txt


### PR DESCRIPTION
Requirements must be installed